### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -111,10 +111,15 @@ if [ $RUNNING -eq 1 ]; then
             echo ""
             zcat shoplogo.fb.gz > /dev/fb$FB
             sleep 3
-            dd if=/dev/zero of=/dev/fb1 bs=153600 count=1 > /dev/null
+            dd if=/dev/zero of=/dev/fb$FB bs=153600 count=1 > /dev/null
 
         fi
 
+        # echo "To start it on boot, don't forget to edit /etc/modules"
+        echo "Adding to /etc/modules..."
+        sudo bash -c "echo rp_usbdisplay >> /etc/modules"
+        echo "Added"
+        
         success "Install finished. Enjoy!"
         echo ""
 


### PR DESCRIPTION
l.114 - the dd reset of the screen was set on a fixed device (/dev/fb1), changed it to automatic detection

~l.118 - automatically add it to /etc/modules (ppl who use the installer may expect that behaviour). Note that maybe sed or equivalent should delete any occurence in the file before (or check for the string in the file). "sudo bash -c" is used to be able to redirect to "/etc/modules"