### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Clone this repo.
 Where `<kernel_version>` is the version of your kernel returned by `uname -a`
 
 Copy `drivers/<kernel_version>/rp_usbdisplay.ko` to `/lib/modules/<kernel_version>/kernel/drivers/video/`
-Copy `drivers/<kernel_version>-v7+/rp_usbdisplay.ko` to `/lib/modules/<kernel_version>/kernel/drivers/video/`
+Copy `drivers/<kernel_version>-v7+/rp_usbdisplay.ko` to `/lib/modules/<kernel_version>-v7+/kernel/drivers/video/`
 
 Run `sudo depmod`
 


### PR DESCRIPTION
l.36 - the copy command wasn't including the "-v7+" suffix in the destination